### PR TITLE
Fixes image rows on Designer to collapse to column on resize

### DIFF
--- a/src/components/ScreenshotCard.js
+++ b/src/components/ScreenshotCard.js
@@ -4,7 +4,11 @@ import { Box, Image, Text } from 'grommet';
 const ScreenshotCard = ({ label, src, a11yTitle }) => (
   <Box>
     <Image src={src} a11yTitle={a11yTitle} />
-    <Text alignSelf="center" color="dark-2" margin={{ top: 'none' }}>
+    <Text
+      alignSelf="center"
+      color="dark-2"
+      margin={{ top: 'none', bottom: 'large' }}
+    >
       {label}
     </Text>
   </Box>

--- a/src/pages/Designer/Designer.js
+++ b/src/pages/Designer/Designer.js
@@ -3,7 +3,6 @@ import {
   Box,
   Button,
   Heading,
-  Stack,
   Paragraph,
   Image,
   Main,

--- a/src/pages/Designer/Designer.js
+++ b/src/pages/Designer/Designer.js
@@ -28,7 +28,6 @@ const Designer = () => (
       </ResponsiveContext.Consumer>
       <Box
         background="YellowBackground"
-        height="large"
         margin={{
           top: 'xlarge',
         }}

--- a/src/pages/Designer/Designer.js
+++ b/src/pages/Designer/Designer.js
@@ -3,6 +3,7 @@ import {
   Box,
   Heading,
   Text,
+  Stack,
   Paragraph,
   Image,
   Main,

--- a/src/pages/Designer/Designer.js
+++ b/src/pages/Designer/Designer.js
@@ -3,7 +3,6 @@ import {
   Box,
   Heading,
   Text,
-  Stack,
   Paragraph,
   Image,
   Main,
@@ -117,110 +116,52 @@ const Designer = () => (
           <BarChart size="large" color="TabularGreen" />
         </Box>
       </Box>
-      <ResponsiveContext.Consumer>
-        {(responsive) =>
-          responsive === 'large' || responsive === 'xlarge' ? (
-            <Stack>
-              <Box
-                background="YellowBackground"
-                height="600px"
-                margin={{
-                  top: 'xlarge',
-                }}
-              ></Box>
-              <Box
-                margin={{
-                  top: 'large',
-                  horizontal: 'xlarge',
-                  bottom: 'medium',
-                }}
-              >
-                <Heading size="large" margin={{ top: 'xlarge' }}>
-                  What is the Designer?
-                </Heading>
-                <Box width="large" margin={{ bottom: 'medim', top: 'none' }}>
-                  <Paragraph fill={true} size="xxlarge">
-                    A free, web-based WSIWG component editor, Grommet Designer
-                    is a themeable experience designer baked on top of react and
-                    java framework. See some examples from Grommet designers
-                    below.
-                  </Paragraph>
-                </Box>
-                <Box
-                  direction="row"
-                  justify="center"
-                  gap="medium"
-                  margin={{ vertical: 'small' }}
-                >
-                  <ScreenshotCard
-                    src="Designer_1.svg"
-                    label="Deisgner File Name"
-                    a11yTitle="Screenshot of Designer Tool"
-                  />
-                  <ScreenshotCard
-                    src="Designer_2.svg"
-                    label="Deisgner File Name"
-                    a11yTitle="Screenshot of Designer Tool"
-                  />
-                  <ScreenshotCard
-                    src="Designer_3.svg"
-                    label="Deisgner File Name"
-                    a11yTitle="Screenshot of Designer Tool"
-                  />
-                </Box>
-              </Box>
-            </Stack>
-          ) : (
-            <Box
-              background="YellowBackground"
-              margin={{
-                top: 'xlarge',
-              }}
-            >
-              <Box
-                margin={{
-                  horizontal: 'xlarge',
-                  bottom: 'medium',
-                }}
-              >
-                <Heading size="large" margin={{ top: 'xlarge' }}>
-                  What is the Designer?
-                </Heading>
-                <Box width="large" margin={{ bottom: 'medium', top: 'none' }}>
-                  <Paragraph fill={true} size="xxlarge">
-                    A free, web-based WSIWG component editor, Grommet Designer
-                    is a themeable experience designer baked on top of react and
-                    java framework. See some examples from Grommet designers
-                    below.
-                  </Paragraph>
-                </Box>
-                <Box
-                  direction="row-responsive"
-                  justify="center"
-                  gap="medium"
-                  margin={{ vertical: 'large' }}
-                >
-                  <ScreenshotCard
-                    src="Designer_1.svg"
-                    label="Deisgner File Name"
-                    a11yTitle="Screenshot of Designer Tool"
-                  />
-                  <ScreenshotCard
-                    src="Designer_2.svg"
-                    label="Deisgner File Name"
-                    a11yTitle="Screenshot of Designer Tool"
-                  />
-                  <ScreenshotCard
-                    src="Designer_3.svg"
-                    label="Deisgner File Name"
-                    a11yTitle="Screenshot of Designer Tool"
-                  />
-                </Box>
-              </Box>
-            </Box>
-          )
-        }
-      </ResponsiveContext.Consumer>
+      <Box
+        background="YellowBackground"
+        margin={{
+          top: 'xlarge',
+        }}
+      >
+        <Box
+          margin={{
+            horizontal: 'xlarge',
+            bottom: 'medium',
+          }}
+        >
+          <Heading size="large" margin={{ top: 'xlarge' }}>
+            What is the Designer?
+          </Heading>
+          <Box width="large" margin={{ bottom: 'medium', top: 'none' }}>
+            <Paragraph fill={true} size="xxlarge">
+              A free, web-based WSIWG component editor, Grommet Designer is a
+              themeable experience designer baked on top of react and java
+              framework. See some examples from Grommet designers below.
+            </Paragraph>
+          </Box>
+          <Box
+            direction="row-responsive"
+            justify="center"
+            gap="medium"
+            margin={{ top: 'large', bottom: '-160px' }}
+          >
+            <ScreenshotCard
+              src="Designer_1.svg"
+              label="Deisgner File Name"
+              a11yTitle="Screenshot of Designer Tool"
+            />
+            <ScreenshotCard
+              src="Designer_2.svg"
+              label="Deisgner File Name"
+              a11yTitle="Screenshot of Designer Tool"
+            />
+            <ScreenshotCard
+              src="Designer_3.svg"
+              label="Deisgner File Name"
+              a11yTitle="Screenshot of Designer Tool"
+            />
+          </Box>
+        </Box>
+      </Box>
 
       <Box height="small"></Box>
       <Box margin={{ top: 'xlarge', horizontal: 'xlarge' }}>

--- a/src/pages/Designer/Designer.js
+++ b/src/pages/Designer/Designer.js
@@ -117,55 +117,111 @@ const Designer = () => (
           <BarChart size="large" color="TabularGreen" />
         </Box>
       </Box>
+      <ResponsiveContext.Consumer>
+        {(responsive) =>
+          responsive === 'large' || responsive === 'xlarge' ? (
+            <Stack>
+              <Box
+                background="YellowBackground"
+                height="600px"
+                margin={{
+                  top: 'xlarge',
+                }}
+              ></Box>
+              <Box
+                margin={{
+                  top: 'large',
+                  horizontal: 'xlarge',
+                  bottom: 'medium',
+                }}
+              >
+                <Heading size="large" margin={{ top: 'xlarge' }}>
+                  What is the Designer?
+                </Heading>
+                <Box width="large" margin={{ bottom: 'medim', top: 'none' }}>
+                  <Paragraph fill={true} size="xxlarge">
+                    A free, web-based WSIWG component editor, Grommet Designer
+                    is a themeable experience designer baked on top of react and
+                    java framework. See some examples from Grommet designers
+                    below.
+                  </Paragraph>
+                </Box>
+                <Box
+                  direction="row"
+                  justify="center"
+                  gap="medium"
+                  margin={{ vertical: 'small' }}
+                >
+                  <ScreenshotCard
+                    src="Designer_1.svg"
+                    label="Deisgner File Name"
+                    a11yTitle="Screenshot of Designer Tool"
+                  />
+                  <ScreenshotCard
+                    src="Designer_2.svg"
+                    label="Deisgner File Name"
+                    a11yTitle="Screenshot of Designer Tool"
+                  />
+                  <ScreenshotCard
+                    src="Designer_3.svg"
+                    label="Deisgner File Name"
+                    a11yTitle="Screenshot of Designer Tool"
+                  />
+                </Box>
+              </Box>
+            </Stack>
+          ) : (
+            <Box
+              background="YellowBackground"
+              margin={{
+                top: 'xlarge',
+              }}
+            >
+              <Box
+                margin={{
+                  horizontal: 'xlarge',
+                  bottom: 'medium',
+                }}
+              >
+                <Heading size="large" margin={{ top: 'xlarge' }}>
+                  What is the Designer?
+                </Heading>
+                <Box width="large" margin={{ bottom: 'medium', top: 'none' }}>
+                  <Paragraph fill={true} size="xxlarge">
+                    A free, web-based WSIWG component editor, Grommet Designer
+                    is a themeable experience designer baked on top of react and
+                    java framework. See some examples from Grommet designers
+                    below.
+                  </Paragraph>
+                </Box>
+                <Box
+                  direction="row-responsive"
+                  justify="center"
+                  gap="medium"
+                  margin={{ vertical: 'large' }}
+                >
+                  <ScreenshotCard
+                    src="Designer_1.svg"
+                    label="Deisgner File Name"
+                    a11yTitle="Screenshot of Designer Tool"
+                  />
+                  <ScreenshotCard
+                    src="Designer_2.svg"
+                    label="Deisgner File Name"
+                    a11yTitle="Screenshot of Designer Tool"
+                  />
+                  <ScreenshotCard
+                    src="Designer_3.svg"
+                    label="Deisgner File Name"
+                    a11yTitle="Screenshot of Designer Tool"
+                  />
+                </Box>
+              </Box>
+            </Box>
+          )
+        }
+      </ResponsiveContext.Consumer>
 
-      <Stack>
-        <Box
-          background="YellowBackground"
-          height="large"
-          margin={{
-            top: 'xlarge',
-          }}
-        ></Box>
-        <Box
-          margin={{
-            horizontal: 'xlarge',
-            bottom: 'xlarge',
-          }}
-        >
-          <Heading size="large" margin={{ top: 'xlarge' }}>
-            What is the Designer?
-          </Heading>
-          <Box width="large" margin={{ bottom: 'xlarge', top: 'none' }}>
-            <Paragraph fill={true} size="xxlarge">
-              A free, web-based WSIWG component editor, Grommet Designer is a
-              themeable experience designer baked on top of react and java
-              framework. See some examples from Grommet designers below.
-            </Paragraph>
-          </Box>
-          <Box
-            direction="row"
-            justify="center"
-            gap="medium"
-            margin={{ vertical: 'xlarge' }}
-          >
-            <ScreenshotCard
-              src="Designer_1.svg"
-              label="Deisgner File Name"
-              a11yTitle="Screenshot of Designer Tool"
-            />
-            <ScreenshotCard
-              src="Designer_2.svg"
-              label="Deisgner File Name"
-              a11yTitle="Screenshot of Designer Tool"
-            />
-            <ScreenshotCard
-              src="Designer_3.svg"
-              label="Deisgner File Name"
-              a11yTitle="Screenshot of Designer Tool"
-            />
-          </Box>
-        </Box>
-      </Stack>
       <Box height="small"></Box>
       <Box margin={{ top: 'xlarge', horizontal: 'xlarge' }}>
         <Box direction="row-responsive">
@@ -204,7 +260,7 @@ const Designer = () => (
           </Box>
         </Box>
         <Box
-          direction="row"
+          direction="row-responsive"
           justify="center"
           margin={{ top: 'medium' }}
           gap="large"


### PR DESCRIPTION
### What does this PR do?
Changes the image rows on Designer so that on large and xlarge window sizes it will overhang background and on smaller window sizes row will collapse into a column

Requesting review from @jcfilben 