### PR TITLE
Modular Capabilities Section

### DIFF
--- a/src/components/common/CapabilitiesLeft.js
+++ b/src/components/common/CapabilitiesLeft.js
@@ -1,0 +1,51 @@
+import React from 'react';
+
+import { Box, Heading, Paragraph, Image } from 'grommet';
+
+import ScreenshotCard from '../../components/ScreenshotCard.js';
+
+const CapabilitiesLeft = ({ content1, content2, images, labels }) => (
+  <Box align="center" margin="xlarge">
+    <Box direction="row-responsive">
+      <Box margin={{ right: 'large' }}>
+        <Heading size="large" margin={{ bottom: 'none', top: 'xlarge' }}>
+          Capabilities
+        </Heading>
+        <Box width="medium">
+          <Paragraph size="xxlarge" color="darkGrey" fill>
+            {content1}
+          </Paragraph>
+          <Paragraph size="large" fill>
+            {content2}
+          </Paragraph>
+        </Box>
+      </Box>
+      <Box
+        alignSelf="end"
+        align="end"
+        margin={{ left: 'xlarge', top: 'medium' }}
+      >
+        <Box>
+          <Image
+            a11yTitle={labels[0]}
+            alignSelf="end"
+            src={images[0]}
+            fill="horizontal"
+            fit="contain"
+          />
+        </Box>
+      </Box>
+    </Box>
+    <Box
+      direction="row-responsive"
+      justify="center"
+      margin={{ top: 'xlarge' }}
+      gap="large"
+    >
+      <ScreenshotCard src={images[1]} label={labels[1]} a11yTitle={labels[1]} />
+      <ScreenshotCard src={images[2]} label={labels[2]} a11yTitle={labels[2]} />
+      <ScreenshotCard src={images[3]} label={labels[3]} a11yTitle={labels[3]} />
+    </Box>
+  </Box>
+);
+export default CapabilitiesLeft;

--- a/src/pages/Designer/Designer.js
+++ b/src/pages/Designer/Designer.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Heading, Paragraph, Image, Main } from 'grommet';
+import { Box, Heading, Paragraph, Main } from 'grommet';
 import {
   ClearOption,
   Configure,
@@ -12,6 +12,7 @@ import AppHeader from '../../components/AppHeader.js';
 import ToolHeader from '../../components/common/ToolHeader.js';
 import ScreenshotCard from '../../components/ScreenshotCard.js';
 import ToolFooter from '../../components/common/ToolFooter.js';
+import CapabilitiesLeft from '../../components/common/CapabilitiesLeft.js';
 
 const Designer = () => (
   <Box>
@@ -80,67 +81,28 @@ const Designer = () => (
         </Box>
       </Box>
 
-      <Box height="small"></Box>
-      <Box margin={{ top: 'xlarge', horizontal: 'xlarge' }}>
-        <Box direction="row-responsive">
-          <Box margin={{ right: 'large' }}>
-            <Heading size="large" margin={{ bottom: 'none', top: 'xlarge' }}>
-              Capabilities
-            </Heading>
-            <Box width="medium">
-              <Paragraph size="large" color="darkGrey" fill>
-                The Designer puts the power in your hands to create sites with
-                built in theming, while leveraging the full extent of grommet’s
-                components and props.
-              </Paragraph>
-              <Paragraph size="large" fill>
-                Open the Designer tool and get started by watching a tutorial or
-                just jumping right in to your first design. Open the Designer
-                tool and get started by watching a tutorial or just jumping
-                right in to your first design.
-              </Paragraph>
-            </Box>
-          </Box>
-          <Box
-            alignSelf="end"
-            align="end"
-            margin={{ left: 'xlarge', top: 'medium' }}
-          >
-            <Box>
-              <Image
-                a11yTitle="Gremlin Holding a Laptop"
-                alignSelf="end"
-                src="gremlin_laptop.svg"
-                fill="horizontal"
-                fit="contain"
-              />
-            </Box>
-          </Box>
-        </Box>
-        <Box
-          direction="row-responsive"
-          justify="center"
-          margin={{ top: 'xlarge' }}
-          gap="large"
-        >
-          <ScreenshotCard
-            src="Designer_4.svg"
-            label="Creating in Light and Dark modes"
-            a11yTitle="Screenshot of Designer Tool"
-          />
-          <ScreenshotCard
-            src="Designer_5.svg"
-            label="Importing your own theme"
-            a11yTitle="Screenshot of Designer Tool"
-          />
-          <ScreenshotCard
-            src="Designer_6.svg"
-            label="Easy publishing"
-            a11yTitle="Screenshot of Designer Tool"
-          />
-        </Box>
-      </Box>
-      <Box height="xsmall"></Box>
+      <CapabilitiesLeft
+        content1="The Designer puts the power in your hands to create sites with
+        built in theming, while leveraging the full extent of grommet’s
+        components and props."
+        content2="Just a few of the Designer’s capabilities include 
+        seamlessly designing in both Light and Dark modes, 
+        importing themes from the Grommet Tools Themer, 
+        and publishing your designs to share with others."
+        images={[
+          'gremlin_laptop.svg',
+          'Designer_4.svg',
+          'Designer_5.svg',
+          'Designer_6.svg',
+        ]}
+        labels={[
+          'Gremlin Holding a Laptop',
+          'Creating in Light and Dark modes',
+          'Importing your own theme',
+          'Easy publishing',
+        ]}
+      />
+
       <ToolFooter
         backgroundColor="YellowBackground"
         headingText="Start Using the Designer Now"


### PR DESCRIPTION
Made the capabilities section on the designer page into a reusable component. I named it CapabilitiesLeft because the text is on the left and the image on the right. There will be other pages where we will need a CapabilitiesRight because the text will be on the right and the image on the left

requesting review from @JoeButler7 