### PR TITLE
Fixed home page card headings

### DIFF
--- a/src/components/GridCard.js
+++ b/src/components/GridCard.js
@@ -15,6 +15,7 @@ import {
 const GridCard = ({
   buttonColor,
   heading,
+  buttonName,
   icon,
   text,
   learnLink,
@@ -40,7 +41,7 @@ const GridCard = ({
       primary
       href={openLink}
       color={buttonColor}
-      label={heading}
+      label={buttonName}
       margin={{ horizontal: 'medium', vertical: 'small' }}
       alignSelf="start"
     ></Button>

--- a/src/components/HomeGrid.js
+++ b/src/components/HomeGrid.js
@@ -21,7 +21,8 @@ const HomeGrid = () => (
   >
     <GridCard
       icon={<ClearOption color="DesignerYellow" size="xlarge" />}
-      heading="Open Designer"
+      heading="Designer"
+      buttonName="Open Designer"
       buttonColor="DesignerYellow"
       learnLink="/Designer"
       openLink="https://designer.grommet.io/"
@@ -31,7 +32,8 @@ const HomeGrid = () => (
     />
     <GridCard
       icon={<Configure size="xlarge" color="ThemerOrange" />}
-      heading="Open Themer"
+      heading="Themer"
+      buttonName="Open Themer"
       buttonColor="ThemerOrange"
       openLink="https://theme-designer.grommet.io/"
       text="Grommet web-based WSIWG component editor. Use
@@ -40,7 +42,8 @@ const HomeGrid = () => (
     />
     <GridCard
       icon={<Camera size="xlarge" color="ImagerOrange" />}
-      heading="Open Images"
+      heading="Images"
+      buttonName="Open Images"
       buttonColor="ImagerOrange"
       openLink="https://images.grommet.io/"
       text="  Super simple image hosting for your Grommet-based
@@ -49,7 +52,8 @@ const HomeGrid = () => (
     />
     <GridCard
       icon={<CloudUpload size="xlarge" color="PublisherPink" />}
-      heading="Open Publisher"
+      heading="Publisher"
+      buttonName="Open Publisher"
       buttonColor="PublisherPink"
       openLink="https://publisher.grommet.io/"
       text="Think one part lightweight CMS,
@@ -58,7 +62,8 @@ const HomeGrid = () => (
     />
     <GridCard
       icon={<Selection size="xlarge" color="SlidesBlue" />}
-      heading="Open Slides"
+      heading="Slides"
+      buttonName="Open Slides"
       buttonColor="SlidesBlue"
       learnLink="/Slides"
       openLink="https://slides.grommet.io/"
@@ -68,7 +73,8 @@ const HomeGrid = () => (
     />
     <GridCard
       icon={<BarChart size="xlarge" color="TabularGreen" />}
-      heading="Open Tabular"
+      heading="Tabular"
+      buttonName="Open Tabular"
       buttonColor="TabularGreen"
       openLink="https://tabular.grommet.io/"
       text="  If you need a table and have an API or data source,


### PR DESCRIPTION
The headings on the home page cards had the word 'Open' in front of them. Fixed the headings so they only have the tool name.

requesting review from @JoeButler7 