### PR TITLE
Fixed anchor spacing

### DIFF
--- a/src/pages/Home/Home.js
+++ b/src/pages/Home/Home.js
@@ -51,10 +51,10 @@ const Home = (props) => (
           }}
           width="medium"
         >
-          <Text size="xlarge">
-            A suite of tools to create even more with&nbsp;
+          <Text size="xlarge" wordBreak="break-word">
+            A suite of tools to create even more with&#32;&#8203;
             <Anchor label="Grommet" href="https://v2.grommet.io/" />
-            &nbsp;components without the stress of handling code.
+            &#8203;&#32;components without the stress of handling code.
           </Text>
         </Box>
         <ResponsiveContext.Consumer>

--- a/src/pages/Home/Home.js
+++ b/src/pages/Home/Home.js
@@ -51,7 +51,7 @@ const Home = (props) => (
           }}
           width="medium"
         >
-          <Text size="xlarge" wordBreak="break-word">
+          <Text size="xlarge">
             A suite of tools to create even more with&#32;&#8203;
             <Anchor label="Grommet" href="https://v2.grommet.io/" />
             &#8203;&#32;components without the stress of handling code.


### PR DESCRIPTION
The Grommet link in the paragraph on the home page was causing weird spacing issues when the screen was small. The &nbsp around the anchor was forcing the surrounding words ('with' and 'components') to always be on the same line as it.
Before:
<img width="463" alt="Screen Shot 2020-07-29 at 4 49 02 PM" src="https://user-images.githubusercontent.com/54560994/88861743-db816000-d1bb-11ea-96cb-367ad65c3fed.png">
After:
<img width="481" alt="Screen Shot 2020-07-29 at 4 48 48 PM" src="https://user-images.githubusercontent.com/54560994/88861767-e50ac800-d1bb-11ea-895e-d58c3d01f13e.png">
