### PR TITLE
Changed margin on home header

### DIFF
--- a/src/pages/Home/Home.js
+++ b/src/pages/Home/Home.js
@@ -27,11 +27,11 @@ import { AppHeader, HomeGrid, SmallCard, RotatedIcon } from '../../components';
 const Home = (props) => (
   <Box>
     <AppHeader />
-    <Main>
+    <Main margin={{ top: 'xlarge' }}>
       <Heading
         level={1}
         margin={{
-          top: 'marginXL',
+          top: 'xlarge',
           left: 'xlarge',
           right: 'xlarge',
           bottom: 'none',

--- a/src/theme.js
+++ b/src/theme.js
@@ -4,8 +4,6 @@ import { deepMerge } from 'grommet/utils';
 export const grommetToolsTheme = deepMerge(grommet, {
   global: {
     edgeSize: {
-      marginXL: '200px',
-      animationBox: '380px',
       none: '0px',
     },
     size: {


### PR DESCRIPTION
Changed the margin on the home header so that it was smaller when the screen is small and uses a t-shirt size instead of a fixed value.

Closes #50 

requesting review from @JoeButler7 