### PR TITLE
Fixed tool header spacing

### DIFF
--- a/src/components/tools/HeadingLarge.js
+++ b/src/components/tools/HeadingLarge.js
@@ -36,11 +36,19 @@ const HeadingLarge = ({
               bottom: 'medium',
             }}
           >
-            <Text> Grommet Tools </Text>
-            <Heading level={1} size="xlarge" margin={{ top: 'none' }}>
+            <Text margin={{ top: 'medium' }}> Grommet Tools </Text>
+            <Heading
+              level={1}
+              size="xlarge"
+              margin={{ top: 'none', bottom: 'medium' }}
+            >
               {title}
             </Heading>
-            <Paragraph margin={{ top: 'none' }} size="xxlarge" color="darkGrey">
+            <Paragraph
+              margin={{ top: 'medium' }}
+              size="xxlarge"
+              color="darkGrey"
+            >
               {content}
             </Paragraph>
             <Button


### PR DESCRIPTION
Changed the spacing on the tool pages header to make the space between the header and the gradient and the gradient and the paragraph more even.