### PR TITLE
Fixed Capabilities Heading

### DIFF
--- a/src/components/tools/CapabilitiesRight.js
+++ b/src/components/tools/CapabilitiesRight.js
@@ -28,6 +28,7 @@ const CapabilitiesRight = ({
           direction="row-responsive"
           margin={{ horizontal: 'xlarge' }}
           justify="between"
+          gap="medium"
         >
           <Box>
             <Image
@@ -39,7 +40,10 @@ const CapabilitiesRight = ({
             />
           </Box>
           <Box>
-            <Heading size="large" margin={{ bottom: 'none', top: 'xlarge' }}>
+            <Heading
+              size={responsive === 'large' ? 'large' : 'medium'}
+              margin={{ bottom: 'none', top: 'xlarge' }}
+            >
               Capabilities
             </Heading>
             <Box width="medium">


### PR DESCRIPTION
Fixes capabilities heading so that it does not go off of the screen when scaling. Also added a gap between the image and capabilities paragraph so they have some space between them when the screen is small.