### PR TITLE
Maximum of 3 cards across on Home

### DIFF
--- a/src/components/home/HomeGrid.js
+++ b/src/components/home/HomeGrid.js
@@ -20,7 +20,11 @@ const HomeGrid = () => (
         rows="auto"
         margin={{ horizontal: 'xlarge', top: 'small', bottom: '-30px' }}
         alignSelf={
-          responsive === 'small' || responsive === 'xsmall' ? 'center' : null
+          responsive === 'small' ||
+          responsive === 'xsmall' ||
+          responsive === 'xlarge'
+            ? 'center'
+            : null
         }
       >
         <GridCard

--- a/src/components/home/HomeGrid.js
+++ b/src/components/home/HomeGrid.js
@@ -16,7 +16,7 @@ const HomeGrid = () => (
     {(responsive) => (
       <Grid
         columns={
-          responsive === 'xlarge' || responsive === 'large'
+          responsive === 'large'
             ? { count: 3, size: 'medium' }
             : { count: 'fill', size: 'medium' }
         }
@@ -24,11 +24,7 @@ const HomeGrid = () => (
         rows="auto"
         margin={{ horizontal: 'xlarge', top: 'small', bottom: '-30px' }}
         alignSelf={
-          responsive === 'small' ||
-          responsive === 'xsmall' ||
-          responsive === 'xlarge'
-            ? 'center'
-            : null
+          responsive === 'small' || responsive === 'xsmall' ? 'center' : null
         }
       >
         <GridCard

--- a/src/components/home/HomeGrid.js
+++ b/src/components/home/HomeGrid.js
@@ -16,7 +16,7 @@ const HomeGrid = () => (
     {(responsive) => (
       <Grid
         columns={
-          responsive === 'xlarge'
+          responsive === 'xlarge' || responsive === 'large'
             ? { count: 3, size: 'medium' }
             : { count: 'fill', size: 'medium' }
         }

--- a/src/components/home/HomeGrid.js
+++ b/src/components/home/HomeGrid.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Grid, ResponsiveContext } from 'grommet';
+import { Box, Grid, ResponsiveContext } from 'grommet';
 import {
   ClearOption,
   Configure,
@@ -15,7 +15,11 @@ const HomeGrid = () => (
   <ResponsiveContext.Consumer>
     {(responsive) => (
       <Grid
-        columns={{ count: 'fill', size: 'medium' }}
+        columns={
+          responsive === 'xlarge'
+            ? { count: 3, size: 'medium' }
+            : { count: 'fill', size: 'medium' }
+        }
         gap="large"
         rows="auto"
         margin={{ horizontal: 'xlarge', top: 'small', bottom: '-30px' }}

--- a/src/components/home/HomeGrid.js
+++ b/src/components/home/HomeGrid.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Box, Grid, ResponsiveContext } from 'grommet';
+import { Grid, ResponsiveContext } from 'grommet';
 import {
   ClearOption,
   Configure,


### PR DESCRIPTION
Before on extra large screens (tested on desktop monitor) the grid cards would have 4 on the first row and two on the second row. Now there is three on each row
<img width="1676" alt="Screen Shot 2020-08-04 at 11 10 56 AM" src="https://user-images.githubusercontent.com/54560994/89323615-36470b80-d643-11ea-89ec-120d4f1abadc.png">

<img width="1689" alt="Screen Shot 2020-08-04 at 11 11 35 AM" src="https://user-images.githubusercontent.com/54560994/89323655-49f27200-d643-11ea-8d5e-411bbdcc8071.png">

