### PR TITLE
Tool Page Margins Mobile

### DIFF
--- a/src/components/tools/CapabilitiesLeft.js
+++ b/src/components/tools/CapabilitiesLeft.js
@@ -26,7 +26,10 @@ const CapabilitiesLeft = ({
       >
         <Box
           direction="row-responsive"
-          margin={{ horizontal: 'xlarge', top: 'xlarge' }}
+          margin={{
+            horizontal: responsive === 'small' ? 'medium' : 'xlarge',
+            top: 'xlarge',
+          }}
           justify="between"
         >
           <Box margin={{ top: 'large' }}>
@@ -62,7 +65,9 @@ const CapabilitiesLeft = ({
             </Box>
           </Box>
         </Box>
-        <Box margin={{ horizontal: 'xlarge' }}>
+        <Box
+          margin={{ horizontal: responsive === 'small' ? 'medium' : 'xlarge' }}
+        >
           <ScreenShotRow
             margin={{ top: 'large' }}
             src={images}

--- a/src/components/tools/CapabilitiesRight.js
+++ b/src/components/tools/CapabilitiesRight.js
@@ -26,7 +26,11 @@ const CapabilitiesRight = ({
       >
         <Box
           direction="row-responsive"
-          margin={{ horizontal: 'xlarge', top: 'xlarge', bottom: 'small' }}
+          margin={{
+            horizontal: responsive === 'small' ? 'medium' : 'xlarge',
+            top: 'xlarge',
+            bottom: 'small',
+          }}
           justify="between"
           gap="medium"
         >
@@ -65,7 +69,9 @@ const CapabilitiesRight = ({
             margin={{ horizontal: 'none', top: 'medium' }}
           ></Box>
         </Box>
-        <Box margin={{ horizontal: 'xlarge' }}>
+        <Box
+          margin={{ horizontal: responsive === 'small' ? 'medium' : 'xlarge' }}
+        >
           <ScreenShotRow
             margin={{ top: 'large' }}
             src={images}

--- a/src/components/tools/Description.js
+++ b/src/components/tools/Description.js
@@ -16,7 +16,7 @@ const Description = ({ title, content, color, images, labels }) => (
           <Box
             margin={{
               vertical: 'xsmall',
-              horizontal: 'xlarge',
+              horizontal: responsive === 'small' ? 'medium' : 'xlarge',
             }}
           >
             <Heading

--- a/src/components/tools/HeadingSmall.js
+++ b/src/components/tools/HeadingSmall.js
@@ -1,28 +1,45 @@
 import React from 'react';
 
-import { Box, Button, Paragraph, Heading, Text } from 'grommet';
+import {
+  Box,
+  Button,
+  Paragraph,
+  Heading,
+  Text,
+  ResponsiveContext,
+} from 'grommet';
 
 const HeadingSmall = ({ title, content, open, link, color }) => (
-  <Box margin={{ vertical: 'xlarge' }}>
-    <Box margin={{ left: 'xlarge' }} pad={{ vertical: 'medium' }}>
-      <Text> Grommet Tools </Text>
-      <Heading level={1} size="xlarge" margin="none">
-        {title}
-      </Heading>
-    </Box>
-    <Box pad="xsmall" background="gradient" />
-    <Box margin={{ left: 'xlarge' }} pad={{ vertical: 'medium' }}>
-      <Paragraph margin={{ top: 'none' }} size="xxlarge" color="darkGrey">
-        {content}
-      </Paragraph>
-      <Button
-        primary
-        href={link}
-        color={color}
-        label={open}
-        alignSelf="start"
-      />
-    </Box>
-  </Box>
+  <ResponsiveContext.Consumer>
+    {(responsive) => (
+      <Box margin={{ vertical: 'xlarge' }}>
+        <Box
+          margin={{ horizontal: responsive === 'small' ? 'medium' : 'xlarge' }}
+          pad={{ vertical: 'medium' }}
+        >
+          <Text> Grommet Tools </Text>
+          <Heading level={1} size="xlarge" margin="none">
+            {title}
+          </Heading>
+        </Box>
+        <Box pad="xsmall" background="gradient" />
+        <Box
+          margin={{ horizontal: responsive === 'small' ? 'medium' : 'xlarge' }}
+          pad={{ vertical: 'medium' }}
+        >
+          <Paragraph margin={{ top: 'none' }} size="xxlarge" color="darkGrey">
+            {content}
+          </Paragraph>
+          <Button
+            primary
+            href={link}
+            color={color}
+            label={open}
+            alignSelf="start"
+          />
+        </Box>
+      </Box>
+    )}
+  </ResponsiveContext.Consumer>
 );
 export { HeadingSmall };


### PR DESCRIPTION
Updated the margins on the tool page so they work better on mobile. Made the pictures on the tool pages easier to see on mobile. Related to issues #78 and #70. Closes #80.