### PR TITLE
Feedback page left align card text

### DIFF
--- a/src/pages/Feedback.js
+++ b/src/pages/Feedback.js
@@ -116,9 +116,9 @@ const Feedback = (props) => (
                       direction="row"
                       width={{ max: '200px' }}
                     >
-                      <CardBody justify="center" align="center" direction="row">
+                      <CardBody align="center" direction="row">
                         <Box pad="xsmall">{item.icon}</Box>
-                        <Text alignSelf="center">
+                        <Text>
                           <b>{item.label}</b> Github
                         </Text>
                       </CardBody>
@@ -146,11 +146,11 @@ const Feedback = (props) => (
                 direction="row"
                 width="small"
               >
-                <CardBody justify="center" align="center" direction="row">
+                <CardBody align="center" direction="row">
                   <Box pad="xsmall">
                     <Grommet />
                   </Box>
-                  <Text alignSelf="center">
+                  <Text>
                     <b>Grommet /</b> Slack
                   </Text>
                 </CardBody>


### PR DESCRIPTION
Changes the text on the feedback cards from being center aligned to left aligned. Closes #74.