### PR TITLE
Improve lighthouse best practices score

### DIFF
--- a/src/components/home/GridCard.js
+++ b/src/components/home/GridCard.js
@@ -68,6 +68,7 @@ const GridCard = ({
       margin={{ horizontal: 'medium', vertical: 'small' }}
       alignSelf="start"
       target="_blank"
+      rel="noreferrer"
     ></Button>
     <CardFooter
       background="light-2"

--- a/src/components/home/SmallCard.js
+++ b/src/components/home/SmallCard.js
@@ -14,7 +14,7 @@ function SmallCard({ size, link, icon, text }) {
       align="center"
       elevation="xsmall"
       onClick={() => {
-        window.open(link, '_blank');
+        window.open(link, '_blank', 'noreferrer');
       }}
     >
       {icon}

--- a/src/components/tools/HeadingLarge.js
+++ b/src/components/tools/HeadingLarge.js
@@ -45,6 +45,8 @@ const HeadingLarge = ({ icons, title, content, open, link, color }) => (
               color={color}
               label={open}
               alignSelf="start"
+              target="_blank"
+              rel="noreferrer"
             />
           </Box>
         </Box>

--- a/src/components/tools/HeadingSmall.js
+++ b/src/components/tools/HeadingSmall.js
@@ -36,6 +36,8 @@ const HeadingSmall = ({ title, content, open, link, color }) => (
             color={color}
             label={open}
             alignSelf="start"
+            target="_blank"
+            rel="noreferrer"
           />
         </Box>
       </Box>

--- a/src/components/tools/ToolFooter.js
+++ b/src/components/tools/ToolFooter.js
@@ -41,6 +41,7 @@ const ToolFooter = ({
         label={buttonLabel}
         href={buttonHref}
         target="_blank"
+        rel="noreferrer"
       />
     </Box>
     <Box pad="xsmall" background="gradient" fill="horizontal" />

--- a/src/pages/Feedback.js
+++ b/src/pages/Feedback.js
@@ -109,7 +109,7 @@ const Feedback = (props) => (
                     <Card
                       key={item.label}
                       onClick={() => {
-                        window.open(item.link, '_blank');
+                        window.open(item.link, '_blank', 'noreferrer');
                       }}
                       background="white"
                       pad="xsmall"
@@ -139,7 +139,11 @@ const Feedback = (props) => (
 
               <Card
                 onClick={() => {
-                  window.open('http://slackin.grommet.io/', '_blank');
+                  window.open(
+                    'http://slackin.grommet.io/',
+                    '_blank',
+                    'noreferrer',
+                  );
                 }}
                 background="white"
                 pad="xsmall"

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -51,7 +51,12 @@ const Home = (props) => (
             >
               <Paragraph size="xxlarge">
                 A suite of tools to create even more with&#32;&#8203;
-                <Anchor label="Grommet" href="https://v2.grommet.io/" />
+                <Anchor
+                  label="Grommet"
+                  href="https://v2.grommet.io/"
+                  rel="noreferrer"
+                  target="_blank"
+                />
                 &#8203;&#32;components without the stress of handling code.
               </Paragraph>
             </Box>
@@ -78,7 +83,11 @@ const Home = (props) => (
                       }
                       animation={{ type: 'jiggle', duration: 2000 }}
                       onClick={() =>
-                        window.open('https://designer.grommet.io', '_blank')
+                        window.open(
+                          'https://designer.grommet.io',
+                          '_blank',
+                          'noreferrer',
+                        )
                       }
                     >
                       <CardBody margin="small">
@@ -98,7 +107,11 @@ const Home = (props) => (
                         delay: 1000,
                       }}
                       onClick={() =>
-                        window.open('https://publisher.grommet.io', '_blank')
+                        window.open(
+                          'https://publisher.grommet.io',
+                          '_blank',
+                          'noreferrer',
+                        )
                       }
                     >
                       <CardBody margin="small">
@@ -120,6 +133,7 @@ const Home = (props) => (
                         window.open(
                           'https://theme-designer.grommet.io',
                           '_blank',
+                          'noreferrer',
                         )
                       }
                     >
@@ -139,7 +153,11 @@ const Home = (props) => (
                       animation={{ type: 'jiggle', duration: 1000, delay: 400 }}
                       margin={{ right: 'large' }}
                       onClick={() =>
-                        window.open('https://tabular.grommet.io', '_blank')
+                        window.open(
+                          'https://tabular.grommet.io',
+                          '_blank',
+                          'noreferrer',
+                        )
                       }
                     >
                       <CardBody margin="small">
@@ -156,7 +174,11 @@ const Home = (props) => (
                       margin={{ left: 'large' }}
                       animation={{ type: 'jiggle', duration: 2300, delay: 600 }}
                       onClick={() =>
-                        window.open('https://slides.grommet.io', '_blank')
+                        window.open(
+                          'https://slides.grommet.io',
+                          '_blank',
+                          'noreferrer',
+                        )
                       }
                     >
                       <CardBody margin="small">
@@ -171,7 +193,11 @@ const Home = (props) => (
                     alignSelf="center"
                     animation={{ type: 'jiggle', duration: 1200, delay: 550 }}
                     onClick={() =>
-                      window.open('https://images.grommet.io', '_blank')
+                      window.open(
+                        'https://images.grommet.io',
+                        '_blank',
+                        'noreferrer',
+                      )
                     }
                   >
                     <CardBody margin="small">
@@ -231,6 +257,7 @@ const Home = (props) => (
                   window.open(
                     'https://medium.com/@marisakuberra/the-power-of-no-code-tools-24b9b0d5f97f',
                     '_blank',
+                    'noreferrer',
                   );
                 }}
                 hoverIndicator
@@ -380,6 +407,7 @@ const Home = (props) => (
                 icon={<Slack />}
                 label="Grommet on Slack"
                 target="_blank"
+                rel="noreferrer"
               />
               <Anchor
                 alignSelf="center"
@@ -387,6 +415,7 @@ const Home = (props) => (
                 icon={<Github />}
                 label="Share feedback on Github"
                 target="_blank"
+                rel="noreferrer"
               />
             </Box>
           </Box>


### PR DESCRIPTION
Added 'noreferrer' to any links that open an external page in a new window. Without 'noreferrer' opening links is a security issue. https://web.dev/external-anchors-use-rel-noopener/?utm_source=lighthouse&utm_medium=devtools
Lighthouse flags anchor links that don't have 'noreferrer' or 'noopener' but it does not flag links within onClick in boxes or cards. Issue #99 

Maybe we should include rel='noopener' and rel='noreferrer' in the Grommet Anchor component as a prop?